### PR TITLE
ref: rename functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ for an example of a complex structure.
 ```go
 data := []byte{0x00, 0x01, 0x02 /* ... */}
 
-nodes, err := tlv.DecodeBytes(data)
+nodes, err := tlv.DecodeAll(data)
 if err != nil {
     panic(err) // invalid payload length vs bytes available
 }
 
 nodes.HasTag(0x0123)        // returns a bool with the tag presence
 nodes.GetByTag(0x0f2a)      // returns a filtered Nodes structure
-nodes.GetFirstByTag(0xabcd) // returns a Node structure with value accessors 
+nodes.GetFirstByTag(0xabcd) // returns a Node structure with value accessors
 ```
 
 ### Byte array decoding as a single TLV node
@@ -62,10 +62,11 @@ if err != nil {
     panic(err) // invalid payload length vs bytes available
 }
 
-n.String()          // returns a base64 representation of the raw message
-n.GetNodes()        // parses the value as TLV and returns a Nodes structure (or error)
-n.GetUint8()        // parses the value as uint8 (returns error if value is too small)
-n.GetPaddedUint8()  // parses the value as uint8 and pads it if too small
+n.Base64()           // returns a base64 representation of the raw message
+n.GetNodes()         // parses the value as TLV and returns a Nodes structure (or error)
+n.GetUint8()         // parses the value as uint8 (returns error if value is too small)
+n.GetPaddedUint32()  // parses the value as uint32 and pads it if too small
+n.GetString()        // parses the value as string
 
 // all available types: bool, uint8, uint16, uint32, uint64, string, time.Time and Nodes
 ```
@@ -88,7 +89,7 @@ decoder, err := tlv.CreateDecoder(4, 4, binary.LittleEndian)
 
 | Type     | Max Length (bytes) | Notes                                                             |
 |----------|-------------------:|-------------------------------------------------------------------|
-| `bool`   |                  1 | Any **non-zero** value is treated as `true`                       | 
+| `bool`   |                  1 | Any **non-zero** value is treated as `true`                       |
 | `uint8`  |                  1 |                                                                   |
 | `uint16` |                  2 |                                                                   |
 | `uint32` |                  4 |                                                                   |
@@ -113,13 +114,13 @@ respectively.
 # Visual representation of a repeated tag in an object-like payload
 message:
   - object:
-      - repeated_tag: a  # this will be a node 
+      - repeated_tag: a  # this will be a node
       - repeated_tag: b  # this will be another node
 ```
 
 ### The decoder supports multiple root level messages
 
-After reading a TLV-encoded message from a byte-array, when using `tlv.DecodeBytes([]byte)` the parser
+After reading a TLV-encoded message from a byte-array, when using `tlv.DecodeAll([]byte)` the parser
 will continue reading the array until it reaches the end. The returned structure will have **all the
 nodes** found in the payload.
 
@@ -176,4 +177,4 @@ means none of it can be trusted.
 
 * **`v1.0.0-alpha1`** (2021-03-14)
   * First release with basic parsing support
-  * ⚠️&nbsp; Methods and structs may change completely 
+  * ⚠️&nbsp; Methods and structs may change completely

--- a/tlv/decoder.go
+++ b/tlv/decoder.go
@@ -12,8 +12,8 @@ import (
 type Decoder interface {
 	// DecodeReader decodes the entire reader data to a list of TLV [Nodes].
 	DecodeReader(reader io.Reader) (Nodes, error)
-	// DecodeBytes decodes a byte array to a list of TLV [Nodes].
-	DecodeBytes(data []byte) (Nodes, error)
+	// DecodeAll decodes a byte array to a list of TLV [Nodes].
+	DecodeAll(data []byte) (Nodes, error)
 	// DecodeSingle decodes a byte array to a single TLV [Node].
 	DecodeSingle(data []byte) (res Node, read uint64, err error)
 	// NewNode creates a new node using the decoder configuration.
@@ -75,11 +75,11 @@ func (d *decoder) DecodeReader(reader io.Reader) (Nodes, error) {
 		return nil, err
 	}
 
-	return d.DecodeBytes(data)
+	return d.DecodeAll(data)
 }
 
-// DecodeBytes decodes a byte array as TLV [Nodes].
-func (d *decoder) DecodeBytes(data []byte) (Nodes, error) {
+// DecodeAll decodes a byte array as TLV [Nodes].
+func (d *decoder) DecodeAll(data []byte) (Nodes, error) {
 	node, read, err := d.DecodeSingle(data)
 	if err != nil {
 		return nil, err
@@ -89,7 +89,7 @@ func (d *decoder) DecodeBytes(data []byte) (Nodes, error) {
 		return Nodes{node}, nil
 	}
 
-	next, err := d.DecodeBytes(data[read:])
+	next, err := d.DecodeAll(data[read:])
 	if err != nil {
 		return nil, err
 	}

--- a/tlv/node.go
+++ b/tlv/node.go
@@ -11,10 +11,13 @@ import (
 
 // Node structure used to represent a decoded TLV message.
 type Node struct {
-	Tag    Tag
+	Tag Tag
+	// Length of value part in bytes.
 	Length Length
-	Value  []byte
-	Raw    []byte
+	// The underlying bytes with value part only.
+	Value []byte
+	// The underlying bytes with tag, length and value parts.
+	Raw []byte
 
 	decoder Decoder
 }
@@ -25,14 +28,14 @@ type Tag uint64
 // Length value size in bytes.
 type Length uint64
 
-// String converts the node bytes to base64.
-func (n *Node) String() string {
+// Base64 converts the node bytes to base64.
+func (n *Node) Base64() string {
 	return base64.StdEncoding.EncodeToString(n.Raw)
 }
 
 // GetNodes parses the value as decoded TLV nodes.
 func (n *Node) GetNodes() (Nodes, error) {
-	return n.getSafeDecoder().DecodeBytes(n.Value)
+	return n.getSafeDecoder().DecodeAll(n.Value)
 }
 
 // GetBool parses the value as boolean if it has enough bytes.

--- a/tlv/standard.go
+++ b/tlv/standard.go
@@ -18,9 +18,9 @@ func DecodeReader(reader io.Reader) (Nodes, error) {
 	return stdDecoder.DecodeReader(reader)
 }
 
-// DecodeBytes decodes a byte array as a list of TLV [Nodes].
-func DecodeBytes(data []byte) (Nodes, error) {
-	return stdDecoder.DecodeBytes(data)
+// DecodeAll decodes a byte array as a list of TLV [Nodes].
+func DecodeAll(data []byte) (Nodes, error) {
+	return stdDecoder.DecodeAll(data)
 }
 
 // DecodeSingle decodes a byte array as a single TLV [Node].

--- a/tlv/standard_test.go
+++ b/tlv/standard_test.go
@@ -45,12 +45,12 @@ func TestDecodeSingle_WhenTheDataIsCorrupted(t *testing.T) {
 	require.Empty(t, node)
 }
 
-func TestDecodeBytes_WhenTheDataIsCorrupted(t *testing.T) {
+func TestDecodeAll_WhenTheDataIsCorrupted(t *testing.T) {
 	corrupted := make([]byte, 0, len(data)*2-5)
 	corrupted = append(corrupted, data...)
 	corrupted = append(corrupted, data[:len(data)-5]...)
 
-	node, err := DecodeBytes(corrupted)
+	node, err := DecodeAll(corrupted)
 
 	require.NotNil(t, err)
 	require.Nil(t, node)


### PR DESCRIPTION
rename DecodeBytes to DecodeAll
rename Node.String to Node.Base64

Currently we have DecodeSingle and
DecodeBytes, but it ambiguous to users
that the DecodeBytes is actually DecodeAll,
and DecodeSingle can also decode 'bytes'.

## Summary

Describe the changes and fixes, or link to an existing issue.

## Checklist

- [ ] I have added code related to the library **scope** that does _not_ focus on a specific use case.  
- [ ] I have _not_ added a new dependency, or the code owners have agreed to it.
- [ ] I have written **tests** for the new code, or the existing tests cover it completely.
- [ ] I have _not_ added `// nolint` comments to the code to fix linter issues.
- [ ] I have _not_ changed configuration files (CI, lint, templates, etc) without authorization.
