### PR TITLE
feat: support to decode array and map

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ n.GetNodes()        // parses the value as TLV and returns a Nodes structure (or
 n.GetUint8()        // parses the value as uint8 (returns error if value is too small)
 n.GetPaddedUint8()  // parses the value as uint8 and pads it if too small
 
-// all available types: bool, uint8, uint16, uint32, uint64, string, time.Time and Nodes
+// all available types: bool, uint8, uint16, uint32, uint64, string, time.Time, Nodes and map[string]*Node
 ```
 
 ### Custom Decoder with different sizes and endianness

--- a/tlv/decoder.go
+++ b/tlv/decoder.go
@@ -20,6 +20,10 @@ type Decoder interface {
 	NewNode(tag Tag, value []byte) Node
 	// GetByteOrder returns the decoder endianness configuration.
 	GetByteOrder() binary.ByteOrder
+	// GetTagSize returns the decoder tag size configuration.
+	GetTagSize() uint8
+	// GetLengthSize returns the decoder length size configuration.
+	GetLengthSize() uint8
 }
 
 type decoder struct {
@@ -135,4 +139,14 @@ func (d *decoder) NewNode(tag Tag, value []byte) Node {
 // GetByteOrder returns the [Decoder] endianness configuration.
 func (d *decoder) GetByteOrder() binary.ByteOrder {
 	return d.byteOrder
+}
+
+// GetTagSize returns the decoder tag size configuration.
+func (d *decoder) GetTagSize() uint8 {
+	return d.tagSize
+}
+
+// GetLengthSize returns the decoder length size configuration.
+func (d *decoder) GetLengthSize() uint8 {
+	return d.lengthSize
 }

--- a/tlv/node.go
+++ b/tlv/node.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"time"
 
+	"github.com/pauloavelar/go-tlv/tlv/internal/errors"
 	"github.com/pauloavelar/go-tlv/tlv/internal/sizes"
 	"github.com/pauloavelar/go-tlv/tlv/internal/utils"
 )
@@ -129,6 +130,80 @@ func (n *Node) GetPaddedUint64() uint64 {
 	padding := utils.GetPadding(sizes.Uint64, len(n.Value))
 
 	return n.getByteOrder().Uint64(append(padding, n.Value...))
+}
+
+// GetVariantArray parses the value as an array. All nodes in the array have individual tag.
+func (n *Node) GetVariantArray() (Nodes, error) {
+	lengthSize := uint64(n.decoder.GetLengthSize())
+	if len(n.Value) < int(lengthSize) {
+		return nil, errors.NewMessageTooShortError(n.Value)
+	}
+	arrayLength := utils.GetPaddedUint64(n.decoder.GetByteOrder(), n.Value[:lengthSize])
+	nodes := make([]Node, 0, arrayLength)
+	offset := lengthSize
+
+	for i := uint64(0); i < arrayLength; i++ {
+		node, read, err := n.decoder.DecodeSingle(n.Value[offset:])
+		if err != nil {
+			return nil, err
+		}
+		offset += read
+		nodes = append(nodes, node)
+	}
+	return nodes, nil
+}
+
+// GetArray parses the value as an array. All nodes in the array have the same tag.
+func (n *Node) GetArray() (Nodes, error) {
+	lengthSize := uint64(n.decoder.GetLengthSize())
+	tagSize := uint64(n.decoder.GetTagSize())
+	if len(n.Value) < int(lengthSize+tagSize) {
+		return nil, errors.NewMessageTooShortError(n.Value)
+	}
+	arrayTag := utils.GetPaddedUint64(n.decoder.GetByteOrder(), n.Value[:tagSize])
+	arrayLength := utils.GetPaddedUint64(n.decoder.GetByteOrder(), n.Value[tagSize:tagSize+lengthSize])
+	nodes := make([]Node, 0, arrayLength)
+	offset := tagSize + lengthSize
+
+	for i := uint64(0); i < arrayLength; i++ {
+		itemLength := utils.GetPaddedUint64(n.decoder.GetByteOrder(), n.Value[offset:offset+lengthSize])
+		offset += lengthSize
+		nodes = append(nodes, Node{
+			Tag:    Tag(arrayTag),
+			Length: Length(itemLength),
+			Value:  n.Value[offset : offset+itemLength],
+			// All the array items use the same tag, so we do not provide raw bytes.
+			Raw: nil,
+		})
+		offset += itemLength
+	}
+	return nodes, nil
+}
+
+// GetStringMap parses the value as an key-value pair, and the key type is string.
+func (n *Node) GetStringMap() (map[string]*Node, error) {
+	lengthSize := uint64(n.decoder.GetLengthSize())
+	if len(n.Value) < int(lengthSize) {
+		return nil, errors.NewMessageTooShortError(n.Value)
+	}
+	mapLength := utils.GetPaddedUint64(n.decoder.GetByteOrder(), n.Value[:lengthSize])
+	nodes := make(map[string]*Node, mapLength)
+	offset := lengthSize
+
+	for i := uint64(0); i < mapLength; i++ {
+		labelLength := utils.GetPaddedUint64(n.decoder.GetByteOrder(), n.Value[offset:offset+lengthSize])
+		offset += lengthSize
+		labelString := string(n.Value[offset : offset+labelLength])
+		offset += labelLength
+
+		node, read, err := n.decoder.DecodeSingle(n.Value[offset:])
+		if err != nil {
+			return nil, err
+		}
+		offset += read
+		nodes[labelString] = &node
+	}
+	return nodes, nil
 }
 
 func (n *Node) getSafeDecoder() Decoder {


### PR DESCRIPTION
Add GetVariantArray to parse the value as an array. 
All nodes in the array have individual tag.

Add GetArray to parse the value as an array.
All nodes in the array have the same tag.

Add GetVariantStringMap to parse the value as an key-value pair, 
the key type is string and each item have individual tag.

Add GetStringMap to parse the value as an key-value pair, 
the key type is string and each item have the same tag.

## Summary

Describe the changes and fixes, or link to an existing issue.

## Checklist

- [ ] I have added code related to the library **scope** that does _not_ focus on a specific use case.  
- [ ] I have _not_ added a new dependency, or the code owners have agreed to it.
- [ ] I have written **tests** for the new code, or the existing tests cover it completely.
- [ ] I have _not_ added `// nolint` comments to the code to fix linter issues.
- [ ] I have _not_ changed configuration files (CI, lint, templates, etc) without authorization.
